### PR TITLE
Changed json import to work with texturepacker 3.7.1 json array 

### DIFF
--- a/Create_Tileset/create_tileset.gd
+++ b/Create_Tileset/create_tileset.gd
@@ -66,7 +66,13 @@ func parseJson(root,image,data):
 	var frames = {}
 	frames.parse_json(data)
 	for imagename in frames.frames:
-		var frame = frames.frames[imagename]["frame"]
+		if(frames.frames.has(imagename):
+			var frame = frames.frames[imagename]["frame"]
+			var spriteName = imagename;
+		else :
+			var frame = imagename["frame"]
+			var spriteName = imagename["filename"]
+
 		var s = Sprite.new()
 		s.set_texture(image)
 		s.set_region(true)
@@ -75,7 +81,7 @@ func parseJson(root,image,data):
 		var pos = Vector2(frame.x,frame.y)
 		s.set_pos(pos)
 		s.set_owner(root)
-		s.set_name(imagename)
+		s.set_name(spriteName)
 	
 func gridBreak(root,image):
 	var r=0


### PR DESCRIPTION
This commit was needed because the format of the latest version of TexturePacker seems to have a different format than the plugin wants.

The way i create Tilemaps in texture packer in order to get this commit to work is.
1) Create new project, JSON (Array).
2) Add sprites and select all images
3) Enter a name in Data file in advanced in Data tab.
4) Publish
